### PR TITLE
Bm navbar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,25 +6,34 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <link rel="stylesheet" href="./styles/main.css">
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+    integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
   <title>Nutshell</title>
 </head>
 
 <body>
+  <div id="main-container">
+    <nav id="main-nav"></nav>
+    <section id="login-section"></section>
+    <section id="friends-section"></section>
+    <section id="users-section"></section>
+    <section id="messages-section"></section>
+    <section id="articles-section"></section>
+    <section id="events-section"></section>
+    <section id="tasks-section"></section>
+  </div>
 
-  <section id="login-section"></section>
-  <section id="friends-section"></section>
-  <section id="users-section"></section>
-  <section id="messages-section"></section>
-  <section id="articles-section"></section>
-  <section id="events-section"></section>
-
-  <section id="tasks-section"></section>
 
   <script src="./bundle.js"></script>
-  <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+  <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+    integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous">
+  </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
+    integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous">
+  </script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
+    integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous">
+  </script>
 </body>
 
 </html>

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -14,4 +14,5 @@
     padding-left: 0px;
     margin-top: 3px;
     margin-bottom: 3px;
+    color: white;
 }

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -1,0 +1,17 @@
+#main-nav {
+    background-color: black;
+    position: fixed;
+    top: 0;
+    width: 100%;
+    overflow: hidden;
+    z-index: 9999;
+
+}
+#main-nav ul {
+    display: flex;
+    justify-content: space-evenly;
+    list-style: none;
+    padding-left: 0px;
+    margin-top: 3px;
+    margin-bottom: 3px;
+}

--- a/src/scripts/HTMLFactory.js
+++ b/src/scripts/HTMLFactory.js
@@ -15,6 +15,15 @@ const HTMLFactory = {
         while (elementToClear.firstChild) {
             elementToClear.removeChild(elementToClear.firstChild);
         }
+    },
+    // Function to build and return list element with anchor and href
+    createLiEl(text) {
+        const newLiElement = document.createElement("li");
+        const newAnchor = document.createElement("a");
+        newAnchor.setAttribute("href", "#");
+        newAnchor.textContent = text;
+        newLiElement.appendChild(newAnchor);
+        return newLiElement
     }
 };
 

--- a/src/scripts/buildNavbar.js
+++ b/src/scripts/buildNavbar.js
@@ -1,0 +1,34 @@
+import HTMLFactory from "./HTMLFactory"
+import loginForm from "./loginScripts/loginForm"
+import clearSection from "./clearSections"
+
+const container = document.querySelector("#login-section");
+const navbar = document.getElementById("main-nav");
+
+const buildNavbar = {
+    buildList() {
+        const sectionList = HTMLFactory.createElementWithText("ul");
+        sectionList.appendChild(HTMLFactory.createElementWithText("li", "Tasks"));
+        sectionList.appendChild(HTMLFactory.createElementWithText("li", "Events"));
+        sectionList.appendChild(HTMLFactory.createElementWithText("li", "Friends"));
+        sectionList.appendChild(HTMLFactory.createElementWithText("li", "Messages"));
+        sectionList.appendChild(HTMLFactory.createElementWithText("li", "Articles"));
+        let welcomeName = (HTMLFactory.createElementWithText("li", "Hello, ", "welcome-name"));
+        sectionList.appendChild(welcomeName);
+        let logoutButton = (HTMLFactory.createElementWithText("button", "Log Out", "logout-button"));
+        logoutButton.addEventListener("click", () => {
+            sessionStorage.clear();
+            clearSection.clearNav();
+            clearSection.clearFriends();
+            clearSection.clearMessages();
+            clearSection.clearArticles();
+            clearSection.clearEvents();
+            clearSection.clearMessages();            
+            container.appendChild(loginForm.createLoginForm());
+        })
+        sectionList.appendChild(logoutButton);
+        navbar.appendChild(sectionList);
+    }
+};
+
+export default buildNavbar

--- a/src/scripts/buildNavbar.js
+++ b/src/scripts/buildNavbar.js
@@ -1,29 +1,62 @@
 import HTMLFactory from "./HTMLFactory"
 import loginForm from "./loginScripts/loginForm"
 import clearSection from "./clearSections"
+import sectionVisibility from "./sectionVisibility"
 
 const container = document.querySelector("#login-section");
+const friendsContainer = document.querySelector("#friends-section");
+const articlesContainer = document.querySelector("#articles-section");
+const eventsContainer = document.querySelector("#events-section");
+const tasksContainer = document.querySelector("#tasks-section");
+const messagesContainer = document.querySelector("#messages-section");
 const navbar = document.getElementById("main-nav");
 
 const buildNavbar = {
+    // Function to build NavBar including links to sections and log out button
     buildList() {
+        let userName = sessionStorage.getItem("userName")
         const sectionList = HTMLFactory.createElementWithText("ul");
-        sectionList.appendChild(HTMLFactory.createElementWithText("li", "Tasks"));
-        sectionList.appendChild(HTMLFactory.createElementWithText("li", "Events"));
-        sectionList.appendChild(HTMLFactory.createElementWithText("li", "Friends"));
-        sectionList.appendChild(HTMLFactory.createElementWithText("li", "Messages"));
-        sectionList.appendChild(HTMLFactory.createElementWithText("li", "Articles"));
-        let welcomeName = (HTMLFactory.createElementWithText("li", "Hello, ", "welcome-name"));
+        const taskLi = HTMLFactory.createLiEl("TASKS");
+        taskLi.addEventListener("click", () => {
+            sectionVisibility.hideAllSections();
+            tasksContainer.style.display = "block";
+        })
+        sectionList.appendChild(taskLi);
+        const eventsLi = HTMLFactory.createLiEl("EVENTS");
+        eventsLi.addEventListener("click", () => {
+            sectionVisibility.hideAllSections();
+            eventsContainer.style.display = "block";
+        })
+        sectionList.appendChild(eventsLi);
+        const friendsLi = HTMLFactory.createLiEl("FRIENDS");
+        friendsLi.addEventListener("click", () => {
+            sectionVisibility.hideAllSections();
+            friendsContainer.style.display = "block";
+        })
+        sectionList.appendChild(friendsLi);
+        const messagesLi = HTMLFactory.createLiEl("MESSAGES");
+        messagesLi.addEventListener("click", () => {
+            sectionVisibility.hideAllSections();
+            messagesContainer.style.display = "block";
+        })
+        sectionList.appendChild(messagesLi);
+        const articlesLi = HTMLFactory.createLiEl("ARTICLES");
+        articlesLi.addEventListener("click", () => {
+            sectionVisibility.hideAllSections();
+            articlesContainer.style.display = "block";
+        })
+        sectionList.appendChild(articlesLi);
+        const showAll = HTMLFactory.createLiEl("SHOW ALL");
+        showAll.addEventListener("click", () => {
+            sectionVisibility.showAllSections();
+        })
+        sectionList.appendChild(showAll);
+        let welcomeName = (HTMLFactory.createElementWithText("li", userName, "user-name"));
         sectionList.appendChild(welcomeName);
         let logoutButton = (HTMLFactory.createElementWithText("button", "Log Out", "logout-button"));
         logoutButton.addEventListener("click", () => {
             sessionStorage.clear();
-            clearSection.clearNav();
-            clearSection.clearFriends();
-            clearSection.clearMessages();
-            clearSection.clearArticles();
-            clearSection.clearEvents();
-            clearSection.clearMessages();            
+            clearSection.clearAllSections();
             container.appendChild(loginForm.createLoginForm());
         })
         sectionList.appendChild(logoutButton);

--- a/src/scripts/clearSections.js
+++ b/src/scripts/clearSections.js
@@ -1,0 +1,33 @@
+const loginContainer = document.querySelector("#login-section");
+const friendsContainer = document.querySelector("#friends-section");
+const articlesContainer = document.querySelector("#articles-section");
+const eventsContainer = document.querySelector("#events-section");
+const tasksContainer = document.querySelector("#tasks-section");
+const messagesContainer = document.querySelector("#messages-section");
+const navbar = document.querySelector("#main-nav");
+
+const clearSection = {
+    clearNav() {
+        HTMLFactory.clearContainer(navbar);
+    },
+    clearFriends() {
+        HTMLFactory.clearContainer(friendsContainer);
+    },
+    clearEvents() {
+        HTMLFactory.clearContainer(eventsContainer);
+    },
+    clearTasks() {
+        HTMLFactory.clearContainer(tasksContainer);
+    },
+    clearArticles() {
+        HTMLFactory.clearContainer(articlesContainer);
+    },
+    clearMessages() {
+        HTMLFactory.clearContainer(messagesContainer);
+    },
+    clearLogin() {
+        HTMLFactory.clearContainer(loginContainer);
+    }
+};
+
+export default clearSection

--- a/src/scripts/clearSections.js
+++ b/src/scripts/clearSections.js
@@ -1,3 +1,5 @@
+import HTMLFactory from "./HTMLFactory"
+
 const loginContainer = document.querySelector("#login-section");
 const friendsContainer = document.querySelector("#friends-section");
 const articlesContainer = document.querySelector("#articles-section");
@@ -7,25 +9,42 @@ const messagesContainer = document.querySelector("#messages-section");
 const navbar = document.querySelector("#main-nav");
 
 const clearSection = {
+    // Function to clear out Nav section
     clearNav() {
         HTMLFactory.clearContainer(navbar);
     },
+    // Function to clear out Friends section
     clearFriends() {
         HTMLFactory.clearContainer(friendsContainer);
     },
+    // Function to clear out Events section
     clearEvents() {
         HTMLFactory.clearContainer(eventsContainer);
     },
+    // Function to clear out Tasks section
     clearTasks() {
         HTMLFactory.clearContainer(tasksContainer);
     },
+    // Function to clear out Articles section
     clearArticles() {
         HTMLFactory.clearContainer(articlesContainer);
     },
+    // Function to clear out Mesages section
     clearMessages() {
         HTMLFactory.clearContainer(messagesContainer);
     },
+    // Function to clear out Login section
     clearLogin() {
+        HTMLFactory.clearContainer(loginContainer);
+    },
+    // Function to clear all sections
+    clearAllSections() {
+        HTMLFactory.clearContainer(navbar);
+        HTMLFactory.clearContainer(friendsContainer);
+        HTMLFactory.clearContainer(eventsContainer);
+        HTMLFactory.clearContainer(tasksContainer);
+        HTMLFactory.clearContainer(articlesContainer);
+        HTMLFactory.clearContainer(messagesContainer);
         HTMLFactory.clearContainer(loginContainer);
     }
 };

--- a/src/scripts/loginScripts/loadPage.js
+++ b/src/scripts/loginScripts/loadPage.js
@@ -1,7 +1,7 @@
 import friendEventHandler from "./../friendScripts/friendEventHandler"
 import eventsData from "../eventScripts/eventsDataManager"
-import eventHTML from "../eventScripts/eventHTML";
-
+import eventHTML from "../eventScripts/eventHTML"
+import buildNavbar from "./../buildNavbar"
 
 
 const loadPage = {
@@ -9,6 +9,10 @@ const loadPage = {
         
         // Calling function to build friend section of DOM
         friendEventHandler.handleAppendFriend()
+
+        // Calling function to build navbar
+        buildNavbar.buildList();
+
         let userID = sessionStorage.getItem("userID");
         return eventsData.getEvents(userID).then(response => {
             return eventHTML.listEventsToDom(response)

--- a/src/scripts/loginScripts/loginHandler.js
+++ b/src/scripts/loginScripts/loginHandler.js
@@ -20,7 +20,8 @@ const loginHandler = {
         API.getUsers().then(users => {
             users.forEach(user => {
                 if (userName === user.userName.toLowerCase() && userEmail === user.email.toLowerCase()) {
-                    sessionStorage.setItem("userID", user.id)
+                    sessionStorage.setItem("userID", user.id);
+                    sessionStorage.setItem("userName", user.userName);
                 }
             })
         }).then(() => {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1,4 +1,4 @@
-import loginForm from "./loginScripts/loginForm";
+import loginForm from "./loginScripts/loginForm"
 
-const container = document.querySelector("#login-section")
-container.appendChild(loginForm.createLoginForm())
+const container = document.querySelector("#login-section");
+container.appendChild(loginForm.createLoginForm());

--- a/src/scripts/sectionVisibility.js
+++ b/src/scripts/sectionVisibility.js
@@ -1,0 +1,28 @@
+const friendsContainer = document.querySelector("#friends-section");
+const articlesContainer = document.querySelector("#articles-section");
+const eventsContainer = document.querySelector("#events-section");
+const tasksContainer = document.querySelector("#tasks-section");
+const messagesContainer = document.querySelector("#messages-section");
+
+const sectionVisibility = {
+    // Function to hide all sections
+    hideAllSections() {
+        friendsContainer.style.display = "none";
+        articlesContainer.style.display = "none";
+        eventsContainer.style.display = "none";
+        tasksContainer.style.display = "none";
+        messagesContainer.style.display = "none";
+        friendsContainer.style.display = "none";
+    },
+    // Function to show all sections
+    showAllSections() {
+        friendsContainer.style.display = "block";
+        articlesContainer.style.display = "block";
+        eventsContainer.style.display = "block";
+        tasksContainer.style.display = "block";
+        messagesContainer.style.display = "block";
+        friendsContainer.style.display = "block";
+    }
+}
+
+export default sectionVisibility


### PR DESCRIPTION
# Description

For fun added a navbar and log out button to clear out session storage.  The bar covers the top section a little but that can be fixed with styling which I am waiting to do at the end. There are section list items at the top that clear out everything from the DOM but that section and a show all button that bring them all back.

Applies to issue # (n/a)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions

1. `git fetch --all`
2. `git checkout bm-navbar`
3. cd into /src/lib and run `grunt`
4. load `http://localhost:8080/` , log into the page with anyone's info. Verify that when you click each section everything but that section is removed from the DOM. Make sure that the show all brings it all back. Also, make sure that the log out button clears session storage and takes you back to the login section

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
